### PR TITLE
hotfix: specify pycountry, tqdm versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ typing-extensions
 types-requests
 types-setuptools
 
-pycountry>=22.3.5
-geopandas>=0.9.0
+pycountry==22.3.5
+geopandas==0.9.0
 fake-useragent==1.3.0
 requests
-tqdm
+tqdm==4.64.1


### PR DESCRIPTION
- newest pycountry versions drop some attributes that cause gadm's crash, so make the libraries' versions fixed
https://github.com/xmba15/gadm/issues/10